### PR TITLE
Fix -Wreorder C5038: Make sure initialisation order is the same as declaration order.

### DIFF
--- a/sources/include/citygml/citygml.h
+++ b/sources/include/citygml/citygml.h
@@ -67,11 +67,11 @@ namespace citygml
             , minLOD( 0 )
             , maxLOD( 4 )
             , optimize( false )
-            , tesselate( true )
             , pruneEmptyObjects( false )
+            , tesselate( true )
+            , keepVertices ( false )
             , destSRS( "" )
             , srcSRS( "" )
-            , keepVertices ( false )
         { }
 
     public:


### PR DESCRIPTION
Fix -Wreorder C5038: Make sure initialisation order is the same as declaration order.